### PR TITLE
VSCode ReLaunch error, workflow fix

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,14 +37,14 @@ async function initializeAfterPythonReady(
 ) {
     try {
         const pythonExt = vscode.extensions.getExtension("ms-python.python");
-        if (!pythonExt?.isActive) {
-            traceError("Error! Python Extension not active!");
-            showOutput();
-        }
         if (!pythonExt) {
             traceError("Error:: Python extension not found.");
             showOutput();
             return;
+        }
+        if (!pythonExt?.isActive) {
+            traceError("Error! Python Extension not active!");
+            showOutput();
         }
 
         await pythonExt.activate();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,6 @@ export const activate = async (context: ExtensionContext): Promise<void> => {
     outputChannel.appendLine("Initializing Waldiez...");
     showOutput();
 
-
     initializeAfterPythonReady(context, outputChannel);
 };
 
@@ -78,7 +77,6 @@ async function initializeAfterPythonReady(
             deactivate();
             return; // Abort activation if no valid Python interpreter is found
         }
-
 
         if (pythonExt?.isActive) {
             outputChannel.appendLine("Python ready. Starting Waldiez...");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,11 +24,10 @@ export const activate = async (context: ExtensionContext): Promise<void> => {
     outputChannel.clear();
     waldiezExtensionDisposables.push(registerLogger(outputChannel)); // Register the logger to use the output channel
 
-    // Register the new custom editor immediately so .waldiez files open (even if Python not ready yet)
-    //const provider = new WaldiezEditorProvider(context);
-    //waldiezExtensionDisposables.push(provider);
-    // Begin Python setup asynchronously (don't block editor registration)
-    //initializeAfterPythonReady(context, provider, outputChannel);
+    outputChannel.appendLine("Initializing Waldiez...");
+    showOutput();
+
+
     initializeAfterPythonReady(context, outputChannel);
 };
 
@@ -50,11 +49,6 @@ async function initializeAfterPythonReady(
         }
 
         await pythonExt.activate();
-
-        if (pythonExt?.isActive) {
-            outputChannel.appendLine("Python Extension Active");
-            showOutput();
-        }
 
         // wait till Python API interpreter is available
 
@@ -83,6 +77,12 @@ async function initializeAfterPythonReady(
 
             deactivate();
             return; // Abort activation if no valid Python interpreter is found
+        }
+
+
+        if (pythonExt?.isActive) {
+            outputChannel.appendLine("Python ready. Starting Waldiez...");
+            showOutput();
         }
 
         // Initialize the FlowRunner, FlowConverter, and custom editor provider

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,26 +25,36 @@ export const activate = async (context: ExtensionContext): Promise<void> => {
     waldiezExtensionDisposables.push(registerLogger(outputChannel)); // Register the logger to use the output channel
 
     // Register the new custom editor immediately so .waldiez files open (even if Python not ready yet)
-    const provider = new WaldiezEditorProvider(context);
-    waldiezExtensionDisposables.push(provider);
+    //const provider = new WaldiezEditorProvider(context);
+    //waldiezExtensionDisposables.push(provider);
     // Begin Python setup asynchronously (don't block editor registration)
     //initializeAfterPythonReady(context, provider, outputChannel);
-    initializeAfterPythonReady(provider, outputChannel);
+    initializeAfterPythonReady(context, outputChannel);
 };
 
 async function initializeAfterPythonReady(
-    //context: ExtensionContext,
-    provider: WaldiezEditorProvider,
+    context: ExtensionContext,
+    //provider: WaldiezEditorProvider,
     outputChannel: vscode.OutputChannel,
 ) {
     try {
         const pythonExt = vscode.extensions.getExtension("ms-python.python");
+        if (!pythonExt?.isActive) {
+            traceError("Error! Python Extension not active!");
+            showOutput();
+        }
         if (!pythonExt) {
-            vscode.window.showErrorMessage("Error:: Python extension not found.");
+            traceError("Error:: Python extension not found.");
+            showOutput();
             return;
         }
 
         await pythonExt.activate();
+
+        if (pythonExt?.isActive) {
+            outputChannel.appendLine("Python Extension Active");
+            showOutput();
+        }
 
         // wait till Python API interpreter is available
 
@@ -61,16 +71,17 @@ async function initializeAfterPythonReady(
         };
         await waitForInterpreterReady();
 
+        // make sure the discovery/refresh cycle is finished
+        const api = pythonExt.exports.environments; // kicks off a scan *and* waits for it to finish
+        await api.refreshEnvironments();
+
         // Ensure a valid Python interpreter (>=3.10, <3=.13) is available
         const wrapper = await PythonWrapper.create(waldiezExtensionDisposables);
         if (!wrapper || !wrapper.executable) {
             traceError("Failed to find a valid Python interpreter (>=3.10, <=3.13)");
-            // showOutput();
-            //vscode.window.showErrorMessage("Failed to find a valid Python interpreter (>=3.10, <=3.13)");
-
-            outputChannel.appendLine("Failed to find a valid Python interpreter (>=3.10, <=3.13)");
             showOutput();
-            //deactivate();
+
+            deactivate();
             return; // Abort activation if no valid Python interpreter is found
         }
 
@@ -81,8 +92,8 @@ async function initializeAfterPythonReady(
         const flowConverter = new FlowConverter(wrapper);
         waldiezExtensionDisposables.push(flowConverter); // Add the FlowConverter to disposables for cleanup
 
-        //const provider = new WaldiezEditorProvider(context, flowRunner, waldiezExtensionDisposables);
-        //waldiezExtensionDisposables.push(provider); // Add the custom editor provider to disposables
+        const provider = new WaldiezEditorProvider(context); //, flowRunner, waldiezExtensionDisposables);
+        waldiezExtensionDisposables.push(provider); // Add the custom editor provider to disposables
         provider.initialize(flowRunner);
 
         // Register extension commands

--- a/src/host/flow/python.ts
+++ b/src/host/flow/python.ts
@@ -133,29 +133,29 @@ export class PythonWrapper {
         disposables: Disposable[],
         onChangePythonInterpreter,
     ) => {
-        try {
-            // Fetch the Python extension API
-            _api = await PythonExtension.api();
-        } catch (e) {
-            showOutput();
-            traceError("Failed to initialize Python extension:", e);
-            return undefined;
-        }
+            try {
+                // Fetch the Python extension API
+                _api = await PythonExtension.api();
+            } catch (e) {
+                showOutput();
+                traceError("Failed to initialize Python extension:", e);
+                return undefined;
+            }
 
-        if (!_api) {
+            if (!_api) {
+                showOutput();
+                traceError("No valid python interpreter found");
+                return undefined;
+            }
+            const resolved = await PythonWrapper.getResolvedEnvironment();
+            if (resolved && PythonWrapper.isVersionAllowed(resolved)) {
+                PythonWrapper.setActiveEnvironmentPath(resolved);
+                return new PythonWrapper(resolved, disposables, onChangePythonInterpreter);
+            }
             showOutput();
             traceError("No valid python interpreter found");
             return undefined;
-        }
-        const resolved = await PythonWrapper.getResolvedEnvironment();
-        if (resolved && PythonWrapper.isVersionAllowed(resolved)) {
-            PythonWrapper.setActiveEnvironmentPath(resolved);
-            return new PythonWrapper(resolved, disposables, onChangePythonInterpreter);
-        }
-        showOutput();
-        traceError("No valid python interpreter found");
-        return undefined;
-    };
+        };
     /**
      * Checks if the given Python environment is in a virtual environment.
      *

--- a/src/host/flow/python.ts
+++ b/src/host/flow/python.ts
@@ -133,29 +133,29 @@ export class PythonWrapper {
         disposables: Disposable[],
         onChangePythonInterpreter,
     ) => {
-            try {
-                // Fetch the Python extension API
-                _api = await PythonExtension.api();
-            } catch (e) {
-                showOutput();
-                traceError("Failed to initialize Python extension:", e);
-                return undefined;
-            }
+        try {
+            // Fetch the Python extension API
+            _api = await PythonExtension.api();
+        } catch (e) {
+            showOutput();
+            traceError("Failed to initialize Python extension:", e);
+            return undefined;
+        }
 
-            if (!_api) {
-                showOutput();
-                traceError("No valid python interpreter found");
-                return undefined;
-            }
-            const resolved = await PythonWrapper.getResolvedEnvironment();
-            if (resolved && PythonWrapper.isVersionAllowed(resolved)) {
-                PythonWrapper.setActiveEnvironmentPath(resolved);
-                return new PythonWrapper(resolved, disposables, onChangePythonInterpreter);
-            }
+        if (!_api) {
             showOutput();
             traceError("No valid python interpreter found");
             return undefined;
-        };
+        }
+        const resolved = await PythonWrapper.getResolvedEnvironment();
+        if (resolved && PythonWrapper.isVersionAllowed(resolved)) {
+            PythonWrapper.setActiveEnvironmentPath(resolved);
+            return new PythonWrapper(resolved, disposables, onChangePythonInterpreter);
+        }
+        showOutput();
+        traceError("No valid python interpreter found");
+        return undefined;
+    };
     /**
      * Checks if the given Python environment is in a virtual environment.
      *


### PR DESCRIPTION
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #1 

<!-- markdownlint-disable MD041 -->

## Description of the Change
Update to relaunching VSCode with an already opened .waldiez file error. 
Now Waldiez extension waits for python extension and interpreter to be ready before launching the editor. Flow runner is working too.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->
<!-- Replace a tick box with NA if the item is not applicable to your PR. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] tests added
- [ ] `CHANGELOG.md` updated (if necessary)
