### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A [waldiez extension](https://marketplace.visualstudio.com/items?itemName=Waldie
 
 ## Known Conflicts
 
-- **autogen-agentchat**: This package conflicts with `ag2` / `pyautogen`. Ensure that `autogen-agentchat` is not installed before installing `waldiez`. If you have already installed `autogen-agentchat`, you can uninstall it with:
+- **autogen-agentchat**: This package conflicts with `ag2` / `ag2`. Ensure that `autogen-agentchat` is not installed before installing `waldiez`. If you have already installed `autogen-agentchat`, you can uninstall it with:
 
     ```shell
     python3 -m pip uninstall -y autogen-agentchat
@@ -37,14 +37,14 @@ A [waldiez extension](https://marketplace.visualstudio.com/items?itemName=Waldie
     If already installed waldiez, you might need to reinstall it after uninstalling `autogen-agentchat`:
 
     ```shell
-    python3 -m pip install --force --no-cache waldiez pyautogen
+    python3 -m pip install --force --no-cache waldiez ag2
     # if you are sure which pip is being used:
     # pip install --force --no-cache waldiez
     # to find the path of the current python interpreter:
     # python3 -c "import sys; print(sys.executable)"
     # in a jupyter notebook this would be:
     # import sys
-    # !{sys.executable} -m pip install --force --no-cache waldiez pyautogen
+    # !{sys.executable} -m pip install --force --no-cache waldiez ag2
     ```
 
 Generally, a new virtual environment is recommended to avoid conflicts:


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
